### PR TITLE
remove incorrect update attribute for time entries

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -388,7 +388,6 @@ time_entries:
     - story_id # (optional) the internal ID of the story this time entry is associated with
     - user_id # (optional) the internal ID of the user the time entry is associated with. This parameter is ignored unless the authorizing user has financial access in the workspace and is on the consultants team (or if the authorizing user is an account administrator and has proxy permissions via an account member with those permissions).
   update_attributes:
-    - workspace_id # (required) the internal ID of the project workspace this time entry is associated with
     - date_performed # (required) the date the activity for which the time is being entered was performed, format: YYYY-MM-DD
     - time_in_minutes # (required) the amount of time entered in minutes
     - billable # (optional) whether this time entry is billable time, you must also provide rate_in_cents if you set billable to true


### PR DESCRIPTION
Updating time entries was failing because it was incorrectly including `workspace_id` in the params. 

@adambedford I tested and verified this -- should be good to go. 